### PR TITLE
Add Transaction Graph visualizer for recursive UTXO tracing

### DIFF
--- a/src/app/api/whatsonchain/route.ts
+++ b/src/app/api/whatsonchain/route.ts
@@ -7,20 +7,8 @@ interface WhatsOnChainRequest {
   data?: unknown;
 }
 
-let lastRequestTime = 0;
-const rateLimitDelay = 350; // 0.35 seconds as per API requirements
-
-async function rateLimit(): Promise<void> {
-  const now = Date.now();
-  const timeSinceLastRequest = now - lastRequestTime;
-  
-  if (timeSinceLastRequest < rateLimitDelay) {
-    const waitTime = rateLimitDelay - timeSinceLastRequest;
-    await new Promise(resolve => setTimeout(resolve, waitTime));
-  }
-  
-  lastRequestTime = Date.now();
-}
+// Rate limiting is handled client-side in whatsonchain.ts RequestQueue
+// Removing server-side rate limiting to prevent double-delay (was causing 1s+ per request)
 
 export async function POST(request: NextRequest) {
   try {
@@ -42,9 +30,6 @@ export async function POST(request: NextRequest) {
         { status: 400 }
       );
     }
-
-    // Apply rate limiting
-    await rateLimit();
 
     const baseUrl = `https://api.whatsonchain.com/v1/bsv/${network}`;
     const url = `${baseUrl}${endpoint}`;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from "react";
 import MerkleTreeVisualizer from "../components/MerkleTreeVisualizer";
 import TxParser from "../components/TxParser";
 import TxWalker from "../components/TxWalker";
+import TxGraph from "../components/TxGraph";
 import Footer from "../components/Footer";
 import Header from "../components/Header";
 import { Network } from "../services/whatsonchain";
@@ -44,6 +45,12 @@ const tools: Tool[] = [
       "Navigate through transaction graphs by exploring inputs and outputs",
     icon: "🚶‍♂️",
   },
+  {
+    id: "tx-graph",
+    name: "Transaction Graph",
+    description: "Recursively trace transaction spending patterns to UTXOs",
+    icon: "🕸️",
+  },
 ];
 
 // Tool metadata configuration for dynamic Open Graph updates
@@ -71,6 +78,12 @@ const toolMetadata = {
     description: "Navigate through Bitcoin SV transaction graphs by exploring inputs and outputs. Trace transaction flows and analyze blockchain connections.",
     ogTitle: "Transaction Walker - Bitcoin SV Graph Explorer",
     ogDescription: "Navigate through Bitcoin SV transaction graphs and trace blockchain connections with interactive exploration tools.",
+  },
+  "tx-graph": {
+    title: "Transaction Graph - BSV Spending Tracer | Noscere Labs",
+    description: "Recursively trace Bitcoin SV transaction spending patterns from a starting TXID to terminal UTXOs and fee-consumed outputs.",
+    ogTitle: "Transaction Graph - BSV Spending Tracer",
+    ogDescription: "Trace Bitcoin SV transaction flows with recursive graph visualization.",
   },
 };
 
@@ -251,6 +264,32 @@ export default function Home() {
 
         <main className="flex-1 max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12 w-full">
           <TxWalker network={network} />
+        </main>
+
+        <Footer />
+      </div>
+    );
+  }
+
+  if (selectedTool === "tx-graph") {
+    return (
+      <div className="min-h-screen bg-black text-white font-sans flex flex-col">
+        <Header
+          breadcrumbs={[
+            {
+              label: "Tools",
+              href: "#",
+              onClick: handleBackToHome,
+            },
+            { label: "Transaction Graph" },
+          ]}
+          showNetworkToggle={true}
+          network={network}
+          onNetworkChange={handleNetworkChange}
+        />
+
+        <main className="flex-1 w-full">
+          <TxGraph network={network} />
         </main>
 
         <Footer />

--- a/src/components/TxGraph.tsx
+++ b/src/components/TxGraph.tsx
@@ -1,0 +1,636 @@
+"use client";
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import { Network, whatsOnChainService } from "../services/whatsonchain";
+import { GraphTraversal } from "../services/graphTraversal";
+import { graphLayout } from "../services/graphLayout";
+import { GraphData, TraversalStatus, TxGraphNode, GraphEdge } from "../types/txGraph";
+
+interface TxGraphProps {
+  network: Network;
+}
+
+const SAMPLE_TXS = {
+  main: [
+    'c1d32f28baa27a376ba977f6a8de6ce0a87041157cef0274b20bfda2b0d8df96',
+    '4bdbdb7483c1c7ef48cda78ee4141af7cf15f94e10324e0bcac43c29394ea4a9',
+  ],
+  test: [
+    '294cd1ebd5689fdee03509f92c32184c0f52f037d4046af250229b97e0c8f1aa',
+  ],
+};
+
+export default function TxGraph({ network }: TxGraphProps) {
+  const [txid, setTxid] = useState("");
+  const [graphData, setGraphData] = useState<GraphData | null>(null);
+  const [status, setStatus] = useState<TraversalStatus>("idle");
+  const [svgDimensions, setSvgDimensions] = useState({ width: 1200, height: 800 });
+  const [selectedNode, setSelectedNode] = useState<string | null>(null);
+  const [minValueBSV, setMinValueBSV] = useState<string>("0");
+  const [maxDepth, setMaxDepth] = useState<string>("4");
+  const [showStats, setShowStats] = useState(false);
+  const traversalRef = useRef<GraphTraversal | null>(null);
+  const lastUpdateTimeRef = useRef<number>(0);
+  const pendingUpdateRef = useRef<{ data: GraphData; status: TraversalStatus } | null>(null);
+  const updateTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  // Initialize from URL parameters on mount
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const params = new URLSearchParams(window.location.search);
+      const urlTxid = params.get('txid');
+      const autoStart = params.get('autostart') === 'true';
+
+      if (urlTxid) {
+        setTxid(urlTxid);
+        // Auto-start traversal if autostart parameter is present
+        if (autoStart && status === 'idle') {
+          // Wait for next tick to ensure state is updated
+          setTimeout(() => {
+            handleStartFromUrl(urlTxid);
+          }, 100);
+        }
+      }
+    }
+  }, []); // Only run on mount
+
+  // Sync network with WhatsOnChain service
+  useEffect(() => {
+    whatsOnChainService.setNetwork(network);
+  }, [network]);
+
+  // Reset when network changes
+  useEffect(() => {
+    if (status === 'running' || status === 'paused') {
+      handleStop();
+    }
+  }, [network]);
+
+  const handleUpdate = useCallback((data: GraphData, newStatus: TraversalStatus) => {
+    const now = Date.now();
+    const timeSinceLastUpdate = now - lastUpdateTimeRef.current;
+
+    // Clone data IMMEDIATELY to capture current state before any throttling logic
+    // This prevents stale data when the traversal continues mutating the original
+    const clonedData: GraphData = {
+      ...data,
+      nodes: new Map(data.nodes),
+      edges: [...data.edges],
+      stats: { ...data.stats },
+    };
+
+    // Throttle updates to max 10 per second (100ms between updates)
+    // But always update on completion or error states
+    const shouldUpdateImmediately =
+      newStatus === 'completed' ||
+      newStatus === 'error' ||
+      newStatus === 'stopped' ||
+      timeSinceLastUpdate >= 100;
+
+    if (shouldUpdateImmediately) {
+      // Clear any pending timeout
+      if (updateTimeoutRef.current) {
+        clearTimeout(updateTimeoutRef.current);
+        updateTimeoutRef.current = null;
+      }
+
+      // Recalculate layout (mutates nodes in place)
+      const dimensions = graphLayout.calculateLayout(clonedData);
+
+      setGraphData(clonedData);
+      setStatus(newStatus);
+      setSvgDimensions(dimensions);
+      lastUpdateTimeRef.current = now;
+      pendingUpdateRef.current = null;
+    } else {
+      // Store the CLONED data (not the original reference) for later
+      pendingUpdateRef.current = { data: clonedData, status: newStatus };
+
+      // Schedule update if not already scheduled
+      if (!updateTimeoutRef.current) {
+        const delay = 100 - timeSinceLastUpdate;
+        updateTimeoutRef.current = setTimeout(() => {
+          updateTimeoutRef.current = null;
+          if (pendingUpdateRef.current) {
+            // Use the already-cloned data directly, don't clone again
+            const dimensions = graphLayout.calculateLayout(pendingUpdateRef.current.data);
+            setGraphData(pendingUpdateRef.current.data);
+            setStatus(pendingUpdateRef.current.status);
+            setSvgDimensions(dimensions);
+            lastUpdateTimeRef.current = Date.now();
+            pendingUpdateRef.current = null;
+          }
+        }, delay);
+      }
+    }
+  }, []);
+
+  // Update URL when starting traversal
+  const updateUrl = (txidValue: string) => {
+    if (typeof window !== 'undefined') {
+      const params = new URLSearchParams(window.location.search);
+      params.set('txid', txidValue);
+      const newUrl = `${window.location.pathname}?${params.toString()}`;
+      window.history.replaceState({}, '', newUrl);
+    }
+  };
+
+  // Get minimum value threshold in BSV (API returns values in BSV)
+  const getMinValueBSV = (): number => {
+    return parseFloat(minValueBSV) || 0;
+  };
+
+  // Get max depth (0 = unlimited)
+  const getMaxDepth = (): number => {
+    const depth = parseInt(maxDepth, 10);
+    return isNaN(depth) ? 4 : depth;
+  };
+
+  const handleStartFromUrl = async (txidValue: string) => {
+    if (!txidValue.trim()) return;
+
+    // Create new traversal instance with minimum value threshold and max depth
+    const minSats = getMinValueBSV();
+    const depth = getMaxDepth();
+    traversalRef.current = new GraphTraversal(handleUpdate, minSats, depth);
+
+    try {
+      await traversalRef.current.startTraversal(txidValue.trim());
+    } catch (error) {
+      console.error("Traversal error:", error);
+      alert(`Error: ${error instanceof Error ? error.message : "Unknown error"}`);
+    }
+  };
+
+  const handleStart = async () => {
+    if (!txid.trim()) {
+      alert("Please enter a transaction ID");
+      return;
+    }
+
+    // Update URL with the txid
+    updateUrl(txid.trim());
+
+    // Create new traversal instance with minimum value threshold and max depth
+    const minSats = getMinValueBSV();
+    const depth = getMaxDepth();
+    traversalRef.current = new GraphTraversal(handleUpdate, minSats, depth);
+
+    try {
+      await traversalRef.current.startTraversal(txid.trim());
+    } catch (error) {
+      console.error("Traversal error:", error);
+      alert(`Error: ${error instanceof Error ? error.message : "Unknown error"}`);
+    }
+  };
+
+  const handlePause = () => {
+    traversalRef.current?.pause();
+  };
+
+  const handleResume = () => {
+    traversalRef.current?.resume();
+  };
+
+  const handleStop = () => {
+    traversalRef.current?.stop();
+  };
+
+  const handleSampleTx = (sampleTxid: string) => {
+    setTxid(sampleTxid);
+  };
+
+  const formatDuration = (seconds: number): string => {
+    if (seconds < 60) return `${seconds.toFixed(1)}s`;
+    const minutes = Math.floor(seconds / 60);
+    const secs = Math.floor(seconds % 60);
+    return `${minutes}m ${secs}s`;
+  };
+
+  const formatSatoshis = (sats: number): string => {
+    return sats.toLocaleString();
+  };
+
+  const formatBSV = (bsv: number): string => {
+    // Values from WhatsOnChain API are already in BSV (not satoshis)
+    // Show up to 4 decimal places for most values
+    if (bsv >= 1) return `${bsv.toFixed(4)} BSV`;
+    if (bsv >= 0.0001) return `${bsv.toFixed(4)} BSV`;
+    // For values smaller than 0.0001 BSV, show 8 decimal places (satoshi precision)
+    return `${bsv.toFixed(8)} BSV`;
+  };
+
+  const copyToClipboard = (text: string) => {
+    navigator.clipboard.writeText(text);
+  };
+
+  const getNodeColor = (type: TxGraphNode['type']): string => {
+    switch (type) {
+      case 'root': return '#a855f7';
+      case 'intermediate': return '#0a84ff';
+      case 'utxo': return '#f59e0b';
+      case 'fee-consumed': return '#ef4444';
+      default: return '#6b7280';
+    }
+  };
+
+  const getNodeDimensions = (type: TxGraphNode['type']): { width: number; height: number } => {
+    switch (type) {
+      case 'root': return { width: 200, height: 60 };
+      case 'intermediate': return { width: 180, height: 50 };
+      case 'utxo': return { width: 160, height: 45 };
+      case 'fee-consumed': return { width: 160, height: 45 };
+      default: return { width: 180, height: 50 };
+    }
+  };
+
+  const renderNode = (node: TxGraphNode) => {
+    const { width, height } = getNodeDimensions(node.type);
+    const color = getNodeColor(node.type);
+    const isSelected = selectedNode === node.txid;
+
+    // Truncate TXID for display
+    const displayTxid = node.txid.length > 16
+      ? `${node.txid.substring(0, 8)}...${node.txid.substring(node.txid.length - 8)}`
+      : node.txid;
+
+    return (
+      <g key={node.txid}>
+        {/* Node rectangle */}
+        <rect
+          x={node.position.x - width / 2}
+          y={node.position.y - height / 2}
+          width={width}
+          height={height}
+          rx={8}
+          fill={color}
+          stroke={isSelected ? '#ffffff' : 'none'}
+          strokeWidth={isSelected ? 2 : 0}
+          className="cursor-pointer hover:brightness-110 transition-all"
+          onClick={() => setSelectedNode(node.txid)}
+        />
+
+        {/* Text */}
+        <text
+          x={node.position.x}
+          y={node.position.y}
+          textAnchor="middle"
+          dominantBaseline="middle"
+          fill="white"
+          fontSize="12"
+          fontFamily="monospace"
+          className="pointer-events-none select-none"
+        >
+          {displayTxid}
+        </text>
+
+        {/* Copy button on hover */}
+        <circle
+          cx={node.position.x + width / 2 - 12}
+          cy={node.position.y - height / 2 + 12}
+          r={8}
+          fill="rgba(0, 0, 0, 0.5)"
+          className="cursor-pointer opacity-0 hover:opacity-100 transition-opacity"
+          onClick={(e) => {
+            e.stopPropagation();
+            copyToClipboard(node.txid);
+          }}
+        />
+        <text
+          x={node.position.x + width / 2 - 12}
+          y={node.position.y - height / 2 + 12}
+          textAnchor="middle"
+          dominantBaseline="middle"
+          fill="white"
+          fontSize="10"
+          className="pointer-events-none select-none"
+        >
+          📋
+        </text>
+      </g>
+    );
+  };
+
+  const renderEdge = (edge: GraphEdge, index: number) => {
+    const fromNode = graphData?.nodes.get(edge.from);
+    const toNode = graphData?.nodes.get(edge.to);
+
+    if (!fromNode || !toNode) return null;
+
+    const fromDims = getNodeDimensions(fromNode.type);
+    const toDims = getNodeDimensions(toNode.type);
+
+    const x1 = fromNode.position.x;
+    const y1 = fromNode.position.y + fromDims.height / 2;
+    const x2 = toNode.position.x;
+    const y2 = toNode.position.y - toDims.height / 2;
+
+    const midX = (x1 + x2) / 2;
+    const midY = (y1 + y2) / 2;
+
+    const edgeColor = edge.type === 'utxo' ? '#f59e0b' : edge.type === 'fee' ? '#ef4444' : '#0a84ff';
+
+    return (
+      <g key={`edge-${index}`}>
+        {/* Edge line */}
+        <line
+          x1={x1}
+          y1={y1}
+          x2={x2}
+          y2={y2}
+          stroke={edgeColor}
+          strokeWidth={2}
+          markerEnd="url(#arrowhead)"
+          opacity={0.6}
+        />
+
+        {/* Edge label - shows BSV value */}
+        <g>
+          <rect
+            x={midX - 45}
+            y={midY - 8}
+            width={90}
+            height={16}
+            rx={4}
+            fill="rgba(0, 0, 0, 0.7)"
+          />
+          <text
+            x={midX}
+            y={midY}
+            textAnchor="middle"
+            dominantBaseline="middle"
+            fill="white"
+            fontSize="10"
+            fontFamily="monospace"
+            className="pointer-events-none select-none"
+          >
+            {formatBSV(edge.value)}
+          </text>
+        </g>
+      </g>
+    );
+  };
+
+  return (
+    <div className="flex flex-col h-[calc(100vh-140px)]">
+      {/* Compact Controls Bar */}
+      <div className="flex-shrink-0 bg-[#0f172a] border-b border-gray-800 px-4 py-3">
+        <div className="flex flex-wrap items-center gap-4">
+          {/* TXID Input */}
+          <div className="flex-1 min-w-[300px] flex gap-2">
+            <input
+              type="text"
+              value={txid}
+              onChange={(e) => setTxid(e.target.value)}
+              placeholder="Enter transaction ID..."
+              className="flex-1 bg-black border border-gray-700 rounded px-3 py-1.5 text-white text-sm focus:outline-none focus:border-[#0a84ff]"
+              disabled={status === 'running'}
+            />
+
+            {(status === 'idle' || status === 'completed' || status === 'stopped') && (
+              <button
+                onClick={handleStart}
+                className="px-4 py-1.5 bg-blue-600 hover:bg-blue-700 text-white text-sm rounded transition-colors"
+              >
+                {status === 'idle' ? 'Start' : 'Restart'}
+              </button>
+            )}
+
+            {status === 'running' && (
+              <>
+                <button
+                  onClick={handlePause}
+                  className="px-4 py-1.5 bg-yellow-600 hover:bg-yellow-700 text-white text-sm rounded transition-colors"
+                >
+                  Pause
+                </button>
+                <button
+                  onClick={handleStop}
+                  className="px-4 py-1.5 bg-red-600 hover:bg-red-700 text-white text-sm rounded transition-colors"
+                >
+                  Stop
+                </button>
+              </>
+            )}
+
+            {status === 'paused' && (
+              <>
+                <button
+                  onClick={handleResume}
+                  className="px-4 py-1.5 bg-green-600 hover:bg-green-700 text-white text-sm rounded transition-colors"
+                >
+                  Resume
+                </button>
+                <button
+                  onClick={handleStop}
+                  className="px-4 py-1.5 bg-red-600 hover:bg-red-700 text-white text-sm rounded transition-colors"
+                >
+                  Stop
+                </button>
+              </>
+            )}
+          </div>
+
+          {/* Parameters */}
+          <div className="flex items-center gap-4">
+            <div className="flex items-center gap-1.5">
+              <label className="text-xs text-[#d1d5db]">Min:</label>
+              <input
+                type="number"
+                value={minValueBSV}
+                onChange={(e) => setMinValueBSV(e.target.value)}
+                placeholder="0"
+                step="0.0001"
+                min="0"
+                className="w-20 bg-black border border-gray-700 rounded px-2 py-1 text-white text-xs focus:outline-none focus:border-[#0a84ff]"
+                disabled={status === 'running'}
+              />
+              <span className="text-xs text-[#d1d5db]">BSV</span>
+            </div>
+
+            <div className="flex items-center gap-1.5">
+              <label className="text-xs text-[#d1d5db]">Depth:</label>
+              <input
+                type="number"
+                value={maxDepth}
+                onChange={(e) => setMaxDepth(e.target.value)}
+                placeholder="4"
+                step="1"
+                min="0"
+                className="w-14 bg-black border border-gray-700 rounded px-2 py-1 text-white text-xs focus:outline-none focus:border-[#0a84ff]"
+                disabled={status === 'running'}
+              />
+            </div>
+          </div>
+
+          {/* Sample buttons */}
+          <div className="flex items-center gap-2">
+            {SAMPLE_TXS[network].map((sampleTxid, idx) => (
+              <button
+                key={idx}
+                onClick={() => handleSampleTx(sampleTxid)}
+                className="px-2 py-1 text-xs bg-gray-700 hover:bg-gray-600 text-white rounded transition-colors"
+                disabled={status === 'running'}
+              >
+                Sample {idx + 1}
+              </button>
+            ))}
+          </div>
+
+          {/* Stats Toggle */}
+          {graphData && (
+            <button
+              onClick={() => setShowStats(!showStats)}
+              className={`px-3 py-1.5 text-xs rounded transition-colors flex items-center gap-1.5 ${
+                showStats ? 'bg-[#0a84ff] text-white' : 'bg-gray-700 hover:bg-gray-600 text-white'
+              }`}
+            >
+              <span>Stats</span>
+              <svg
+                className={`w-3 h-3 transition-transform ${showStats ? 'rotate-180' : ''}`}
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+              </svg>
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Collapsible Statistics Panel */}
+      <div
+        className={`flex-shrink-0 bg-[#0f172a] border-b border-gray-800 overflow-hidden transition-all duration-300 ease-in-out ${
+          showStats && graphData ? 'max-h-40 opacity-100' : 'max-h-0 opacity-0'
+        }`}
+      >
+        <div className="px-4 py-3">
+          <div className="flex flex-wrap items-center gap-6 text-sm">
+            <div className="flex items-center gap-2">
+              <span className="text-[#d1d5db]">Nodes:</span>
+              <span className="font-bold text-[#0a84ff]">{graphData?.stats.totalNodes || 0}</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="text-[#d1d5db]">UTXOs:</span>
+              <span className="font-bold text-[#f59e0b]">{graphData?.stats.totalUTXOs || 0}</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="text-[#d1d5db]">Depth:</span>
+              <span className="font-bold text-[#a855f7]">{graphData?.stats.maxDepth || 0}</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="text-[#d1d5db]">Time:</span>
+              <span className="font-bold text-white">{graphData ? formatDuration(graphData.stats.elapsedTime) : '0s'}</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="text-[#d1d5db]">Fees:</span>
+              <span className="font-bold text-[#ef4444]">{formatSatoshis(graphData?.stats.totalFeeConsumed || 0)} sats</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="text-[#d1d5db]">API Calls:</span>
+              <span className="font-bold text-white">{graphData?.stats.apiCallsCount || 0}</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="text-[#d1d5db]">Queue:</span>
+              <span className="font-bold text-white">{graphData?.stats.queueSize || 0}</span>
+            </div>
+            <div className="flex items-center gap-2">
+              <span className="text-[#d1d5db]">Status:</span>
+              <span className="font-bold text-white capitalize">{status}</span>
+              {status === 'running' && (
+                <div className="w-3 h-3 border-2 border-blue-500 border-t-transparent rounded-full animate-spin"></div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {/* Full-Page Graph Area */}
+      <div className="flex-1 relative overflow-hidden bg-black">
+        {/* Empty state */}
+        {(!graphData || graphData.nodes.size === 0) && (
+          <div className="absolute inset-0 flex items-center justify-center">
+            <div className="text-center text-gray-500">
+              <svg className="w-16 h-16 mx-auto mb-4 opacity-50" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1} d="M13 10V3L4 14h7v7l9-11h-7z" />
+              </svg>
+              <p className="text-lg">Enter a transaction ID and click Start</p>
+              <p className="text-sm mt-2">or try one of the sample transactions</p>
+            </div>
+          </div>
+        )}
+
+        {/* Graph SVG - Full area */}
+        {graphData && graphData.nodes.size > 0 && (
+          <div className="absolute inset-0 overflow-auto">
+            <svg
+              width={Math.max(svgDimensions.width, 1200)}
+              height={Math.max(svgDimensions.height, 600)}
+              className="min-w-full"
+            >
+              {/* Arrow marker definition */}
+              <defs>
+                <marker
+                  id="arrowhead"
+                  markerWidth="10"
+                  markerHeight="10"
+                  refX="9"
+                  refY="3"
+                  orient="auto"
+                  markerUnits="strokeWidth"
+                >
+                  <polygon points="0 0, 10 3, 0 6" fill="#0a84ff" />
+                </marker>
+              </defs>
+
+              {/* Render edges first (behind nodes) */}
+              {graphData.edges.map((edge, idx) => renderEdge(edge, idx))}
+
+              {/* Render nodes */}
+              {Array.from(graphData.nodes.values()).map(node => renderNode(node))}
+            </svg>
+          </div>
+        )}
+
+        {/* Floating Legend - Bottom Left */}
+        {graphData && graphData.nodes.size > 0 && (
+          <div className="absolute bottom-4 left-4 bg-black/80 backdrop-blur-sm rounded-lg p-3 border border-gray-700">
+            <div className="flex flex-wrap gap-3 text-xs">
+              <div className="flex items-center gap-1.5">
+                <div className="w-3 h-3 rounded" style={{ backgroundColor: '#a855f7' }}></div>
+                <span className="text-[#d1d5db]">Root</span>
+              </div>
+              <div className="flex items-center gap-1.5">
+                <div className="w-3 h-3 rounded" style={{ backgroundColor: '#0a84ff' }}></div>
+                <span className="text-[#d1d5db]">Intermediate</span>
+              </div>
+              <div className="flex items-center gap-1.5">
+                <div className="w-3 h-3 rounded" style={{ backgroundColor: '#f59e0b' }}></div>
+                <span className="text-[#d1d5db]">UTXO</span>
+              </div>
+              <div className="flex items-center gap-1.5">
+                <div className="w-3 h-3 rounded" style={{ backgroundColor: '#ef4444' }}></div>
+                <span className="text-[#d1d5db]">Fee</span>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Selected Node Details - Bottom Right */}
+        {selectedNode && graphData && (
+          <div className="absolute bottom-4 right-4 bg-black/80 backdrop-blur-sm rounded-lg p-3 border border-gray-700 max-w-sm">
+            <div className="text-xs text-[#d1d5db] mb-1">Selected Node</div>
+            <div className="font-mono text-xs break-all text-[#0a84ff]">{selectedNode}</div>
+            <button
+              onClick={() => copyToClipboard(selectedNode)}
+              className="mt-2 px-2 py-1 text-xs bg-gray-700 hover:bg-gray-600 text-white rounded transition-colors"
+            >
+              Copy TXID
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/services/graphLayout.ts
+++ b/src/services/graphLayout.ts
@@ -1,0 +1,72 @@
+/**
+ * Graph Layout Service
+ *
+ * Handles hierarchical layout positioning for transaction graph nodes
+ */
+
+import { GraphData, TxGraphNode, LayoutConfig } from '../types/txGraph';
+
+export class GraphLayout {
+  private config: LayoutConfig = {
+    nodeWidth: 180,
+    nodeHeight: 60,
+    levelHeight: 150,
+    minNodeSpacing: 40,
+    paddingX: 100,
+    paddingY: 100,
+  };
+
+  public calculateLayout(graphData: GraphData): { width: number; height: number } {
+    // Group nodes by level
+    const nodesByLevel = this.groupNodesByLevel(graphData.nodes);
+
+    // Calculate SVG dimensions
+    const maxNodesInLevel = Math.max(...Array.from(nodesByLevel.values()).map(nodes => nodes.length));
+    const svgWidth = Math.max(
+      1200,
+      maxNodesInLevel * (this.config.nodeWidth + this.config.minNodeSpacing) + 2 * this.config.paddingX
+    );
+    const svgHeight = nodesByLevel.size * this.config.levelHeight + 2 * this.config.paddingY;
+
+    // Position nodes level by level
+    nodesByLevel.forEach((nodes, level) => {
+      this.positionNodesAtLevel(nodes, level, svgWidth);
+    });
+
+    return { width: svgWidth, height: svgHeight };
+  }
+
+  private groupNodesByLevel(nodes: Map<string, TxGraphNode>): Map<number, TxGraphNode[]> {
+    const grouped = new Map<number, TxGraphNode[]>();
+
+    nodes.forEach(node => {
+      if (!grouped.has(node.level)) {
+        grouped.set(node.level, []);
+      }
+      grouped.get(node.level)!.push(node);
+    });
+
+    return grouped;
+  }
+
+  private positionNodesAtLevel(nodes: TxGraphNode[], level: number, svgWidth: number): void {
+    const y = this.config.paddingY + level * this.config.levelHeight;
+    const availableWidth = svgWidth - 2 * this.config.paddingX;
+    const spacing = nodes.length > 1 ? availableWidth / (nodes.length + 1) : availableWidth / 2;
+
+    nodes.forEach((node, index) => {
+      node.position.x = this.config.paddingX + spacing * (index + 1);
+      node.position.y = y;
+    });
+  }
+
+  public getConfig(): LayoutConfig {
+    return { ...this.config };
+  }
+
+  public setConfig(config: Partial<LayoutConfig>): void {
+    this.config = { ...this.config, ...config };
+  }
+}
+
+export const graphLayout = new GraphLayout();

--- a/src/services/graphTraversal.ts
+++ b/src/services/graphTraversal.ts
@@ -1,0 +1,440 @@
+/**
+ * Graph Traversal Service
+ *
+ * Handles recursive BFS traversal of Bitcoin transaction graphs,
+ * following spent outputs until reaching UTXOs or fee-consumed endpoints.
+ */
+
+import { whatsOnChainService, TransactionInfo } from './whatsonchain';
+import {
+  GraphData,
+  GraphStats,
+  TxGraphNode,
+  GraphEdge,
+  TraversalQueueItem,
+  TxOutput,
+  TraversalStatus,
+} from '../types/txGraph';
+
+export class GraphTraversal {
+  private queue: TraversalQueueItem[] = [];
+  private graphData: GraphData;
+  private status: TraversalStatus = 'idle';
+  private startTime: number = 0;
+  private onUpdate: (data: GraphData, status: TraversalStatus) => void;
+  private processedOutputs: Set<string> = new Set(); // Track txid:vout to avoid duplicates
+  private txCache: Map<string, TransactionInfo> = new Map(); // Cache fetched transactions
+  private minValueBSV: number; // Minimum value in BSV to follow (0 = follow all)
+  private maxDepth: number; // Maximum depth to traverse (0 = unlimited)
+
+  constructor(
+    onUpdate: (data: GraphData, status: TraversalStatus) => void,
+    minValueBSV: number = 0,
+    maxDepth: number = 4
+  ) {
+    this.onUpdate = onUpdate;
+    this.minValueBSV = minValueBSV;
+    this.maxDepth = maxDepth;
+    this.graphData = this.createEmptyGraphData();
+  }
+
+  private createEmptyGraphData(): GraphData {
+    return {
+      nodes: new Map(),
+      edges: [],
+      rootTxid: '',
+      stats: {
+        totalNodes: 0,
+        totalUTXOs: 0,
+        totalFeeConsumed: 0,
+        maxDepth: 0,
+        totalValue: 0,
+        elapsedTime: 0,
+        apiCallsCount: 0,
+        queueSize: 0,
+        errors: 0,
+      },
+    };
+  }
+
+  public async startTraversal(startTxid: string): Promise<void> {
+    // Reset state
+    this.queue = [];
+    this.graphData = this.createEmptyGraphData();
+    this.graphData.rootTxid = startTxid;
+    this.processedOutputs.clear();
+    this.txCache.clear();
+    this.startTime = Date.now();
+    this.status = 'running';
+
+    try {
+      // Fetch the starting transaction (and cache it)
+      const rootTx = await this.getTransactionCached(startTxid);
+
+      // Create root node
+      const rootNode = this.createNode(rootTx, 0, 'root');
+      this.graphData.nodes.set(startTxid, rootNode);
+      this.graphData.stats.totalNodes++;
+
+      // Enqueue all outputs for processing (filter by minimum value threshold)
+      for (const output of rootTx.vout) {
+        // Skip outputs below the minimum value threshold
+        if (this.minValueBSV > 0 && output.value < this.minValueBSV) {
+          continue;
+        }
+        this.enqueue({
+          txid: startTxid,
+          parentTxid: startTxid,
+          vout: output.n,
+          level: 0,
+          value: output.value,
+        });
+      }
+
+      // Trigger initial update
+      this.updateStats();
+      this.onUpdate(this.graphData, this.status);
+
+      // Process the queue
+      await this.processQueue();
+
+      // Mark as completed
+      this.status = 'completed';
+      this.updateStats();
+      this.onUpdate(this.graphData, this.status);
+    } catch (error) {
+      console.error('Error starting traversal:', error);
+      this.status = 'error';
+      this.graphData.stats.errors++;
+      this.onUpdate(this.graphData, this.status);
+      throw error;
+    }
+  }
+
+  private async processQueue(): Promise<void> {
+    while (this.queue.length > 0 && this.status === 'running') {
+      const item = this.dequeue();
+      if (!item) break;
+
+      // Check status again before processing
+      if (this.status !== 'running') {
+        break;
+      }
+
+      // Skip if already processed
+      const outputKey = `${item.txid}:${item.vout}`;
+      if (this.processedOutputs.has(outputKey)) {
+        continue;
+      }
+      this.processedOutputs.add(outputKey);
+
+      try {
+        await this.processOutput(item);
+
+        // Update graph after EVERY node for progressive visualization
+        this.updateStats();
+        this.onUpdate(this.graphData, this.status);
+      } catch (error) {
+        const errorMessage = error instanceof Error ? error.message : String(error);
+        console.error(`❌ Error processing ${item.txid}:${item.vout}:`, errorMessage);
+        console.error(`   Level: ${item.level}, Parent: ${item.parentTxid}`);
+        console.error(`   Full error:`, error);
+        this.graphData.stats.errors++;
+        // Continue with next item despite error
+      }
+    }
+  }
+
+  private async processOutput(item: TraversalQueueItem): Promise<void> {
+    // Check if we should stop
+    if (this.status !== 'running') {
+      return;
+    }
+
+    // Check if output is spent (retries handled by WhatsOnChainService)
+    const spentInfo = await whatsOnChainService.getSpentStatus(item.txid, item.vout);
+    this.graphData.stats.apiCallsCount++;
+
+    // Check again after async operation
+    if (this.status !== 'running') {
+      return;
+    }
+
+    const parentNode = this.graphData.nodes.get(item.parentTxid);
+    if (!parentNode) {
+      console.warn(`Parent node not found: ${item.parentTxid}`);
+      return;
+    }
+
+    // Update parent node's output info
+    const output = parentNode.outputs.find(o => o.vout === item.vout);
+    if (output) {
+      output.isSpent = spentInfo !== null;
+      if (spentInfo) {
+        output.spentBy = spentInfo.txid;
+      }
+    }
+
+    if (!spentInfo) {
+      // UTXO found - terminus condition
+      this.handleUTXO(item, parentNode);
+      return;
+    }
+
+    // Check status before continuing
+    if (this.status !== 'running') {
+      return;
+    }
+
+    // Output is spent - fetch spending transaction (with caching)
+    const spendingTx = await this.getTransactionCached(spentInfo.txid);
+
+    // Check again after async operation
+    if (this.status !== 'running') {
+      return;
+    }
+
+    // Calculate total output value (fast - no API calls needed)
+    const totalOutputValue = spendingTx.vout.reduce((sum, out) => sum + out.value, 0);
+
+    // Quick check: if outputs are zero or very small, it's likely fee-consumed
+    // Skip expensive input value calculation for most cases
+    if (totalOutputValue === 0) {
+      // Definitely fee consumed - all value went to fees
+      this.handleFeeConsumed(item, spendingTx, item.value);
+      return;
+    }
+
+    // For non-zero outputs, continue traversal without calculating exact fees
+    // This avoids the expensive input value calculation that was causing stalls
+    // Fee calculation can be done as a background task later if needed
+
+    // Continue traversal - add spending tx to graph
+    if (!this.graphData.nodes.has(spendingTx.txid)) {
+      const childNode = this.createNode(spendingTx, item.level + 1, 'intermediate');
+      this.graphData.nodes.set(spendingTx.txid, childNode);
+      this.graphData.stats.totalNodes++;
+
+      // Update max depth
+      if (item.level + 1 > this.graphData.stats.maxDepth) {
+        this.graphData.stats.maxDepth = item.level + 1;
+      }
+    }
+
+    // Add edge
+    this.graphData.edges.push({
+      from: item.parentTxid,
+      to: spendingTx.txid,
+      vout: item.vout,
+      value: item.value,
+      type: 'spending',
+    });
+
+    // Check if we've reached max depth (0 = unlimited)
+    if (this.maxDepth > 0 && item.level + 1 >= this.maxDepth) {
+      // Don't enqueue further - we've reached the depth limit
+      return;
+    }
+
+    // Enqueue all outputs of spending transaction (filter by minimum value threshold)
+    for (const output of spendingTx.vout) {
+      // Skip outputs below the minimum value threshold
+      if (this.minValueBSV > 0 && output.value < this.minValueBSV) {
+        continue;
+      }
+      this.enqueue({
+        txid: spendingTx.txid,
+        parentTxid: spendingTx.txid,
+        vout: output.n,
+        level: item.level + 1,
+        value: output.value,
+      });
+    }
+  }
+
+  private handleUTXO(item: TraversalQueueItem, parent: TxGraphNode): void {
+    const utxoId = `${item.txid}:${item.vout}`;
+
+    // Create UTXO node
+    const utxoNode: TxGraphNode = {
+      txid: utxoId,
+      level: item.level + 1,
+      type: 'utxo',
+      position: { x: 0, y: 0 },
+      outputs: [],
+      totalValue: item.value,
+      visited: true,
+      timestamp: Date.now(),
+    };
+
+    this.graphData.nodes.set(utxoId, utxoNode);
+    this.graphData.stats.totalNodes++;
+    this.graphData.stats.totalUTXOs++;
+
+    // Update max depth
+    if (item.level + 1 > this.graphData.stats.maxDepth) {
+      this.graphData.stats.maxDepth = item.level + 1;
+    }
+
+    // Add edge
+    this.graphData.edges.push({
+      from: item.parentTxid,
+      to: utxoId,
+      vout: item.vout,
+      value: item.value,
+      type: 'utxo',
+    });
+  }
+
+  private handleFeeConsumed(item: TraversalQueueItem, tx: TransactionInfo, fee: number): void {
+    const feeId = `${tx.txid}:fee`;
+
+    // Create fee-consumed node
+    const feeNode: TxGraphNode = {
+      txid: feeId,
+      level: item.level + 1,
+      type: 'fee-consumed',
+      position: { x: 0, y: 0 },
+      outputs: [],
+      totalValue: fee,
+      visited: true,
+      timestamp: Date.now(),
+    };
+
+    this.graphData.nodes.set(feeId, feeNode);
+    this.graphData.stats.totalNodes++;
+    this.graphData.stats.totalFeeConsumed += fee;
+
+    // Update max depth
+    if (item.level + 1 > this.graphData.stats.maxDepth) {
+      this.graphData.stats.maxDepth = item.level + 1;
+    }
+
+    // Add edge
+    this.graphData.edges.push({
+      from: item.parentTxid,
+      to: feeId,
+      vout: item.vout,
+      value: fee,
+      type: 'fee',
+    });
+  }
+
+  private async getTransactionCached(txid: string): Promise<TransactionInfo> {
+    // Check cache first
+    if (this.txCache.has(txid)) {
+      return this.txCache.get(txid)!;
+    }
+
+    // Fetch and cache (rate limiting and retries handled by WhatsOnChainService)
+    const tx = await whatsOnChainService.getTransaction(txid);
+    this.graphData.stats.apiCallsCount++;
+    this.txCache.set(txid, tx);
+    return tx;
+  }
+
+  private async calculateInputValue(tx: TransactionInfo): Promise<number> {
+    let totalValue = 0;
+
+    // Process inputs sequentially to respect rate limiting
+    for (const input of tx.vin) {
+      // Check if we should stop
+      if (this.status !== 'running') {
+        break;
+      }
+
+      // Skip coinbase inputs (they don't have a txid)
+      if (!input.txid) {
+        continue;
+      }
+
+      try {
+        // Fetch the input transaction to get the output value (with caching)
+        const inputTx = await this.getTransactionCached(input.txid);
+
+        // Check again after async operation
+        if (this.status !== 'running') {
+          break;
+        }
+
+        const output = inputTx.vout[input.vout];
+        if (output) {
+          totalValue += output.value;
+        }
+      } catch (error) {
+        console.error(`Error fetching input tx ${input.txid}:`, error);
+        this.graphData.stats.errors++;
+      }
+    }
+
+    return totalValue;
+  }
+
+  private createNode(tx: TransactionInfo, level: number, type: TxGraphNode['type']): TxGraphNode {
+    const outputs: TxOutput[] = tx.vout.map(vout => ({
+      vout: vout.n,
+      value: vout.value,
+      isSpent: false,
+      address: vout.scriptPubKey?.addresses?.[0],
+    }));
+
+    const totalValue = outputs.reduce((sum, out) => sum + out.value, 0);
+
+    return {
+      txid: tx.txid,
+      level,
+      type,
+      position: { x: 0, y: 0 },
+      outputs,
+      totalValue,
+      visited: false,
+      timestamp: Date.now(),
+      confirmations: tx.confirmations,
+    };
+  }
+
+  private enqueue(item: TraversalQueueItem): void {
+    this.queue.push(item);
+  }
+
+  private dequeue(): TraversalQueueItem | null {
+    return this.queue.shift() || null;
+  }
+
+  private updateStats(): void {
+    this.graphData.stats.elapsedTime = (Date.now() - this.startTime) / 1000;
+    this.graphData.stats.queueSize = this.queue.length;
+  }
+
+  public pause(): void {
+    if (this.status === 'running') {
+      this.status = 'paused';
+      this.updateStats();
+      this.onUpdate(this.graphData, this.status);
+    }
+  }
+
+  public resume(): void {
+    if (this.status === 'paused') {
+      this.status = 'running';
+      this.processQueue();
+    }
+  }
+
+  public stop(): void {
+    this.status = 'stopped';
+    // Clear the queue to prevent any pending operations
+    this.queue = [];
+    this.updateStats();
+    this.onUpdate(this.graphData, this.status);
+    console.log('Traversal stopped. Queue cleared.');
+  }
+
+  public getStatus(): TraversalStatus {
+    return this.status;
+  }
+
+  public getGraphData(): GraphData {
+    return this.graphData;
+  }
+}

--- a/src/types/txGraph.ts
+++ b/src/types/txGraph.ts
@@ -1,0 +1,71 @@
+/**
+ * TX Graph Type Definitions
+ *
+ * Data structures for recursive transaction graph visualization
+ */
+
+export interface TxOutput {
+  vout: number;           // Output index
+  value: number;          // Value in satoshis
+  isSpent: boolean;       // Whether this output has been spent
+  spentBy?: string;       // TXID of the spending transaction (if spent)
+  address?: string;       // Destination address (optional)
+}
+
+export interface TxGraphNode {
+  txid: string;                    // Transaction ID
+  level: number;                   // Distance from root (0 = starting tx)
+  type: 'root' | 'intermediate' | 'utxo' | 'fee-consumed';
+  position: { x: number; y: number };
+  outputs: TxOutput[];             // All outputs from this transaction
+  totalValue: number;              // Sum of all output values in satoshis
+  visited: boolean;                // Traversal tracking flag
+  timestamp?: number;              // When this node was fetched
+  confirmations?: number;          // Number of confirmations
+}
+
+export interface GraphEdge {
+  from: string;                    // Parent transaction ID
+  to: string;                      // Child transaction ID or UTXO identifier
+  vout: number;                    // Output index being spent
+  value: number;                   // Value flowing through this edge (satoshis)
+  type: 'spending' | 'utxo' | 'fee';
+}
+
+export interface GraphStats {
+  totalNodes: number;              // Total transactions discovered
+  totalUTXOs: number;              // Terminal unspent outputs found
+  totalFeeConsumed: number;        // Total satoshis consumed by fees
+  maxDepth: number;                // Maximum distance from root
+  totalValue: number;              // Total value flowing through graph
+  elapsedTime: number;             // Seconds since traversal started
+  apiCallsCount: number;           // Number of API calls made
+  queueSize: number;               // Current queue size
+  errors: number;                  // Number of errors encountered
+}
+
+export interface GraphData {
+  nodes: Map<string, TxGraphNode>;
+  edges: GraphEdge[];
+  rootTxid: string;
+  stats: GraphStats;
+}
+
+export interface TraversalQueueItem {
+  txid: string;                    // Transaction containing the output
+  parentTxid: string;              // Parent transaction for graph building
+  vout: number;                    // Which output index to check
+  level: number;                   // Depth level in the graph
+  value: number;                   // Value of this output
+}
+
+export type TraversalStatus = 'idle' | 'running' | 'paused' | 'stopped' | 'completed' | 'error';
+
+export interface LayoutConfig {
+  nodeWidth: number;
+  nodeHeight: number;
+  levelHeight: number;             // Vertical spacing between levels
+  minNodeSpacing: number;          // Minimum horizontal spacing between nodes
+  paddingX: number;                // Horizontal padding
+  paddingY: number;                // Vertical padding
+}


### PR DESCRIPTION
## Summary

- Add new **Transaction Graph** tool for recursively tracing Bitcoin SV transaction spending patterns from a starting TXID to terminal UTXOs and fee-consumed outputs
- Implement BFS graph traversal with configurable depth limits and minimum value thresholds
- Create interactive SVG-based visualization with color-coded node types (root/intermediate/UTXO/fee-consumed)
- Improve WhatsOnChain API client with global request queue, exponential backoff, and automatic retry handling

## Technical Details

### New Components
- `TxGraph.tsx` - Main visualization component with compact controls bar, collapsible statistics panel, and full-page SVG graph area
- `graphTraversal.ts` - BFS traversal service that follows spent outputs until reaching UTXOs or fee-consumed endpoints
- `graphLayout.ts` - Hierarchical layout positioning for transaction graph nodes
- `txGraph.ts` - TypeScript type definitions for graph data structures

### API Improvements
- Consolidated rate limiting from server-side to client-side `RequestQueue` class (prevents double-delay issue)
- Added exponential backoff for 429 rate limit errors (1s, 2s, 4s, 8s, 16s max)
- Implemented retry logic with configurable attempts for transient failures
- Transaction caching to minimize redundant API calls

### UI Features
- Network toggle support (mainnet/testnet)
- Real-time statistics display (nodes, UTXOs, depth, elapsed time, API calls, queue size)
- URL parameter support for txid and autostart
- Sample transactions for quick testing
- Copy-to-clipboard for all transaction IDs

## Testing Notes

- Test with sample transactions on both mainnet and testnet
- Verify traversal respects depth limits and minimum value thresholds
- Confirm stop/pause/resume controls work correctly during active traversal
- Check that rate limiting prevents 429 errors under normal usage